### PR TITLE
Allow account creator to establish trust lines for the new account

### DIFF
--- a/src/test/TxTests.cpp
+++ b/src/test/TxTests.cpp
@@ -261,6 +261,19 @@ changeTrust(Asset const& asset, int64_t limit)
 }
 
 Operation
+changeTrust(Asset const& asset, int64_t limit, AccountID account)
+{
+    Operation op;
+
+    op.body.type(CHANGE_TRUST);
+    op.body.changeTrustOp().limit = limit;
+    op.body.changeTrustOp().line = asset;
+    op.sourceAccount.activate() = account;
+
+    return op;
+}
+
+Operation
 allowTrust(PublicKey const& trustor, Asset const& asset, bool authorize)
 {
     Operation op;

--- a/src/test/TxTests.cpp
+++ b/src/test/TxTests.cpp
@@ -112,7 +112,7 @@ void
 checkTransaction(TransactionFrame& txFrame, Application& app)
 {
     REQUIRE(txFrame.getResult().feeCharged ==
-            app.getLedgerManager().getTxFee());
+            app.getLedgerManager().getTxFee() * txFrame.getOperations().size());
     REQUIRE((txFrame.getResultCode() == txSUCCESS ||
              txFrame.getResultCode() == txFAILED));
 }

--- a/src/test/TxTests.h
+++ b/src/test/TxTests.h
@@ -67,6 +67,7 @@ transactionFromOperations(Application& app, SecretKey const& from,
                           std::vector<Operation> const& ops);
 
 Operation changeTrust(Asset const& asset, int64_t limit);
+Operation changeTrust(Asset const& asset, int64_t limit, AccountID account);
 
 Operation allowTrust(PublicKey const& trustor, Asset const& asset,
                      bool authorize);


### PR DESCRIPTION
A transaction which includes a `CREATE_ACCOUNT` operation may also include one or more `CHANGE_TRUST` operations for the new account.  It is unnecessary for the new account to sign the transaction.