### PR TITLE
Allow account creators to establish trust lines for the new account(s).

### DIFF
--- a/src/test/TxTests.cpp
+++ b/src/test/TxTests.cpp
@@ -261,6 +261,19 @@ changeTrust(Asset const& asset, int64_t limit)
 }
 
 Operation
+changeTrust(Asset const& asset, int64_t limit, AccountID account)
+{
+    Operation op;
+
+    op.body.type(CHANGE_TRUST);
+    op.body.changeTrustOp().limit = limit;
+    op.body.changeTrustOp().line = asset;
+    op.sourceAccount.activate() = account;
+
+    return op;
+}
+
+Operation
 allowTrust(PublicKey const& trustor, Asset const& asset, bool authorize)
 {
     Operation op;

--- a/src/test/TxTests.cpp
+++ b/src/test/TxTests.cpp
@@ -112,7 +112,7 @@ void
 checkTransaction(TransactionFrame& txFrame, Application& app)
 {
     REQUIRE(txFrame.getResult().feeCharged ==
-            app.getLedgerManager().getTxFee());
+            app.getLedgerManager().getTxFee() * txFrame.getOperations().size());
     REQUIRE((txFrame.getResultCode() == txSUCCESS ||
              txFrame.getResultCode() == txFAILED));
 }

--- a/src/test/TxTests.h
+++ b/src/test/TxTests.h
@@ -67,6 +67,7 @@ transactionFromOperations(Application& app, SecretKey const& from,
                           std::vector<Operation> const& ops);
 
 Operation changeTrust(Asset const& asset, int64_t limit);
+Operation changeTrust(Asset const& asset, int64_t limit, AccountID account);
 
 Operation allowTrust(PublicKey const& trustor, Asset const& asset,
                      bool authorize);

--- a/src/transactions/ChangeTrustTests.cpp
+++ b/src/transactions/ChangeTrustTests.cpp
@@ -75,7 +75,7 @@ TEST_CASE("change trust", "[tx][changetrust]")
                 REQUIRE_NOTHROW(a2.changeTrust(idr, 0));
             });
         }
-        SECTION("create, then trust") {
+        SECTION("create, then trust (separate tx) should fail") {
             for_all_versions(*app, [&] {
                 auto sk = getAccount("crust2");
 

--- a/src/transactions/OperationFrame.cpp
+++ b/src/transactions/OperationFrame.cpp
@@ -175,9 +175,9 @@ OperationFrame::checkValid(SignatureChecker& signatureChecker, Application& app,
 
     if (mOperation.body.type() == CHANGE_TRUST)
     {
-	for (auto const& opFrame : mParentTx.getOperations())
-	{
-            auto body = opFrame->getOperation().body;
+        for (auto const& opFrame : mParentTx.getOperations())
+        {
+            auto const& body = opFrame->getOperation().body;
 
             if (body.type() == CREATE_ACCOUNT &&
                 body.createAccountOp().destination == *mOperation.sourceAccount)


### PR DESCRIPTION
A transaction which includes a `CREATE_ACCOUNT` operation may also include one or more `CHANGE_TRUST` operations for the new account.  It is unnecessary for the new account to sign the transaction.