### PR TITLE
Add whitelist address to the data returned by /info.

### DIFF
--- a/src/main/ApplicationImpl.cpp
+++ b/src/main/ApplicationImpl.cpp
@@ -244,6 +244,7 @@ ApplicationImpl::getJsonInfo()
     info["peers"]["authenticated_count"] =
         getOverlayManager().getAuthenticatedPeersCount();
     info["network"] = getConfig().NETWORK_PASSPHRASE;
+    info["whitelist"] = getConfig().WHITELIST;
 
     auto& statusMessages = getStatusManager();
     auto counter = 0;


### PR DESCRIPTION
Example

```
{
   "info" : {
      "UNSAFE_QUORUM" : "UNSAFE QUORUM ALLOWED",
      "build" : "v10.0.0-25-gb88fc4b0-dirty",
      "history" : {
         "cache" : {
            "failure" : 0,
            "success" : 0
         }
      },
      "ledger" : {
         "age" : 2,
         "baseFee" : 1,
         "baseReserve" : 0,
         "closeTime" : 1545048590,
         "hash" : "e70111a7b064791b719e025723fd81e907909eef5adba89cb0bac1540e3647bc",
         "maxTxSetSize" : 100,
         "num" : 45,
         "version" : 9
      },
      "network" : "private testnet",
      "peers" : {
         "authenticated_count" : 0,
         "pending_count" : 0
      },
      "protocol_version" : 10,
      "quorum" : {
         "44" : {
            "agree" : 1,
            "disagree" : 0,
            "fail_at" : 0,
            "hash" : "f61feb",
            "missing" : 0,
            "phase" : "EXTERNALIZE",
            "validated" : true
         }
      },
      "startedOn" : "2018-12-17T12:09:20Z",
      "state" : "Synced!",
      "whitelist" : "GBDYQPNVH7DGKD6ZNBTZY5BZNO2GRHAY7KO3U33UZRBXJDVLBF2PCF6M"
   }
}
```