### PR TITLE
Whitelist fixes

### DIFF
--- a/src/herder/TxSetFrame.cpp
+++ b/src/herder/TxSetFrame.cpp
@@ -341,12 +341,23 @@ TxSetFrame::trimInvalid(Application& app,
 
     auto processInvalidTxLambda = [&](TransactionFramePtr tx,
                                       SequenceNumber lastSeq) {
+        CLOG(DEBUG, "Herder")
+            << "bad txSet: " << hexAbbrev(mPreviousLedgerHash) << " tx invalid"
+            << " lastSeq:" << lastSeq
+            << " tx: " << xdr::xdr_to_string(tx->getEnvelope())
+            << " result: " << tx->getResultCode();
+
         trimmed.push_back(tx);
         removeTx(tx);
         return true;
     };
     auto processInsufficientBalance =
         [&](vector<TransactionFramePtr> const& item) {
+            CLOG(DEBUG, "Herder")
+                << "bad txSet: " << hexAbbrev(mPreviousLedgerHash)
+                << " account can't pay fee"
+                << " tx:" << xdr::xdr_to_string(item.back()->getEnvelope());
+
             for (auto& tx : item)
             {
                 trimmed.push_back(tx);

--- a/src/main/ManagedDataCache.cpp
+++ b/src/main/ManagedDataCache.cpp
@@ -22,7 +22,7 @@ ManagedDataCache::update()
 {
     auto id = getAccount();
 
-    if (id.size() == 0 || lcl >= mApp.getLedgerManager().getLastClosedLedgerNum())
+    if (id.size() == 0 || needsUpdate == false)
         return;
 
     AccountID aid(KeyUtils::fromStrKey<PublicKey>(id));
@@ -30,6 +30,6 @@ ManagedDataCache::update()
 
     // Handle dataframe objects
     fulfill(dfs);
-    lcl = mApp.getLedgerManager().getLastClosedLedgerNum();
+    needsUpdate = false;
 }
 }

--- a/src/main/ManagedDataCache.cpp
+++ b/src/main/ManagedDataCache.cpp
@@ -30,6 +30,8 @@ ManagedDataCache::update()
 
     // Handle dataframe objects
     fulfill(dfs);
+    
     needsUpdate = false;
+    updateCounter++;
 }
 }

--- a/src/main/ManagedDataCache.h
+++ b/src/main/ManagedDataCache.h
@@ -23,6 +23,11 @@ class ManagedDataCache
         needsUpdate = true;
     }
 
+    uint32_t getUpdateCounter()
+    {
+        return updateCounter;
+    }
+    
     std::shared_ptr<AccountID> accountID();
 
     void update();
@@ -34,5 +39,6 @@ class ManagedDataCache
 
   private:
     bool needsUpdate;
+    uint32_t updateCounter = 0;
 };
 }

--- a/src/main/ManagedDataCache.h
+++ b/src/main/ManagedDataCache.h
@@ -15,7 +15,12 @@ class ManagedDataCache
   public:
     ManagedDataCache(Application& app) : mApp(app)
     {
-        lcl = 0;
+        needsUpdate = true;
+    }
+
+    void setNeedsUpdate()
+    {
+        needsUpdate = true;
     }
 
     std::shared_ptr<AccountID> accountID();
@@ -28,6 +33,6 @@ class ManagedDataCache
     Application& mApp;
 
   private:
-    uint32_t lcl = 0;
+    bool needsUpdate;
 };
 }

--- a/src/main/Whitelist.cpp
+++ b/src/main/Whitelist.cpp
@@ -27,6 +27,10 @@ void Whitelist::fulfill(std::vector<DataFrame::pointer> dfs)
             auto name = data.dataName;
             auto value = data.dataValue;
 
+            // If the value isn't 4 bytes long, skip the entry.
+            if (value.size() != 4)
+                continue;
+
             int32_t intVal =
                 (value[0] << 24) + (value[1] << 16) + (value[2] << 8) + value[3];
 
@@ -44,9 +48,17 @@ void Whitelist::fulfill(std::vector<DataFrame::pointer> dfs)
                 continue;
             }
 
-            std::vector<string64> keys = whitelist[intVal];
-            keys.emplace_back(name);
-            whitelist[intVal] = keys;
+            try
+            {
+                // An exception is thrown if the key isn't convertible.  The entry is then skipped.
+                KeyUtils::fromStrKey<PublicKey>(name);
+
+                std::vector<string64> keys = whitelist[intVal];
+                keys.emplace_back(name);
+                whitelist[intVal] = keys;
+            }
+            catch (...)
+            {}
         }
 }
 

--- a/src/main/Whitelist.cpp
+++ b/src/main/Whitelist.cpp
@@ -2,6 +2,7 @@
 #include "ledger/DataFrame.h"
 #include "transactions/SignatureUtils.h"
 #include "transactions/TransactionFrame.h"
+#include "util/Logging.h"
 #include <stdint.h>
 #include <unordered_map>
 
@@ -29,7 +30,12 @@ void Whitelist::fulfill(std::vector<DataFrame::pointer> dfs)
 
             // If the value isn't 4 bytes long, skip the entry.
             if (value.size() != 4)
+            {
+                CLOG(INFO, "Whitelist")
+                    << "bad value for: " << name;
+
                 continue;
+            }
 
             int32_t intVal =
                 (value[0] << 24) + (value[1] << 16) + (value[2] << 8) + value[3];
@@ -58,7 +64,10 @@ void Whitelist::fulfill(std::vector<DataFrame::pointer> dfs)
                 whitelist[intVal] = keys;
             }
             catch (...)
-            {}
+            {
+                CLOG(INFO, "Whitelist")
+                    << "bad public key: " << name;
+            }
         }
 }
 

--- a/src/transactions/ManageDataOpFrame.cpp
+++ b/src/transactions/ManageDataOpFrame.cpp
@@ -8,6 +8,7 @@
 #include "ledger/DataFrame.h"
 #include "ledger/LedgerDelta.h"
 #include "main/Application.h"
+#include "main/Whitelist.h"
 #include "medida/meter.h"
 #include "medida/metrics_registry.h"
 #include "util/Logging.h"
@@ -87,6 +88,11 @@ ManageDataOpFrame::doApply(Application& app, LedgerDelta& delta,
         mSourceAccount->addNumEntries(-1, ledgerManager);
         mSourceAccount->storeChange(delta, db);
         dataFrame->storeDelete(delta, db);
+    }
+
+    auto wlID = *app.getWhitelist().accountID().get();
+    if (getSourceID() == wlID) {
+        app.getWhitelist().setNeedsUpdate();
     }
 
     innerResult().code(MANAGE_DATA_SUCCESS);

--- a/src/transactions/TransactionFrame.cpp
+++ b/src/transactions/TransactionFrame.cpp
@@ -82,12 +82,12 @@ TransactionFrame::clearCached()
 bool
 TransactionFrame::isWhitelisted(Application& app)
 {
-    auto lastLedger = app.getLedgerManager().getLastClosedLedgerNum();
-    if (mCheckedLedger < lastLedger)
+    auto counter = app.getWhitelist().getUpdateCounter();
+    if (mWhitelistCounter < counter)
     {
         mIsWhitelisted = app.getWhitelist().isWhitelisted(getEnvelope().signatures,
                                                           getContentsHash());
-        mCheckedLedger = lastLedger;
+        mWhitelistCounter = counter;
     }
 
     return mIsWhitelisted;

--- a/src/transactions/TransactionFrame.h
+++ b/src/transactions/TransactionFrame.h
@@ -39,7 +39,7 @@ class TransactionFrame
 {
   private:
     bool mIsWhitelisted = false;
-    uint32_t mCheckedLedger = 0;
+    uint32_t mWhitelistCounter = 0;
 
   protected:
     TransactionEnvelope mEnvelope;


### PR DESCRIPTION
- invalid data entries on the whitelist holder's account should not break the core.
- whitelist results are only invalidated when the whitelist changes.
- the whitelist is only changed if a MANAGE_DATA_OP is issued on the whitelist holder's account.