### PR TITLE
Whitelist fixes

### DIFF
--- a/src/main/ManagedDataCache.cpp
+++ b/src/main/ManagedDataCache.cpp
@@ -30,7 +30,7 @@ ManagedDataCache::update()
 
     // Handle dataframe objects
     fulfill(dfs);
-    
+
     needsUpdate = false;
     updateCounter++;
 }


### PR DESCRIPTION
- Invalidate the whitelist upon application of a MANAGE_DATA_OP on the whitelist holder's account.
- Skip invalid data entries on the whitelist account.
- Invalidate the cached whitelist status only when the whitelist has changed.